### PR TITLE
Made subscriber count work with non-English locales

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -17,7 +17,7 @@
     // e.g. ... "subscriberCountText":"12.4K subscribers" ...
 
     // We just do a regex to find it for now
-    const regex = /"subscriberCountText":"[a-zA-Z0-9.]+ subscribers"/;
+    const regex = /"subscriberCountText":"([^"]+)"/;
     const match = text.match(regex);
 
     // User has set their subscriber count to private.
@@ -25,11 +25,8 @@
     if (match === null) return '<i>Private</i>';
 
     // We now have a string like: "subscriberCountText":"2 subscribers"
-    // We extract the "2 subscribers" part as a string
-    let subCountStringRaw = match[0].substring(23, match[0].length-1);
-
-    let subCount = subCountStringRaw.split(' ')[0];
-    return `${subCount} subscriber${subCount === '1' ? '' : 's'}`;
+    // with the count in match group 1, so return just that.
+    return match[1];
   }
 
 


### PR DESCRIPTION
This will use the regular expression to directly extract the subscriber count to be inserted.

As a small neat bonus feature, this will make the final public display (except "Private") localized, too!

![Example screenshot from YouTube using the German locale setting](https://github.com/mattyhempstead/yt-comment-sub-count/assets/1854245/59fe1833-3834-4eae-b1c5-55a123dbd803)