### PR TITLE
Handle new comment DOM structure

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -36,6 +36,8 @@
    * @param {HTMLElement} commentElement an element which contains a single comment
    */
   const addCommentSubCount = async commentElement => {
+    const newCommentStructure = !commentElement.querySelector('div#author-thumbnail > a').href;
+    const channelUrlLookup = newCommentStructure ? 'div#header-author a' : 'div#author-thumbnail > a';
     const commentHeaderElement = commentElement.querySelector('div#header-author');
 
     // Remove any existing subscriber counts
@@ -43,7 +45,7 @@
       commentHeaderElement.removeChild(el);
     });
 
-    const channelUrl = commentElement.querySelector('div#author-thumbnail > a').href;
+    const channelUrl = commentElement.querySelector(channelUrlLookup).href;
     const subCount = await getSubs(channelUrl);
 
     // Add new subscriber count
@@ -74,14 +76,14 @@
         .forEach(async () => {
           // Hide element while we fetch new subscriber count
           subCounterSpan.style.visibility = 'hidden';
-          const channelUrl = commentElement.querySelector('div#author-thumbnail > a').href;
+          const channelUrl = commentElement.querySelector(channelUrlLookup).href;
           subCounterSpan.innerHTML = await getSubs(channelUrl);
           subCounterSpan.style.visibility = 'visible';
         })
     });
 
     observer.observe(
-      commentElement.querySelector('div#author-thumbnail > a'),
+      commentElement.querySelector(channelUrlLookup),
       {childList: false, subtree: false, attributes: true}
     );
 


### PR DESCRIPTION
I'm not sure if this is a new A/B test or a permanent change, but I noticed subscriber counts being gone again and a large amount of CORS warnings in the browser console (since the determined channel URL is now an empty string, resulting in tons of requests to YouTube's about page redirect).

Turns out YouTube removed the `href` from anchors within user thumbnails and instead now shows a popup card with channel information. (This is actually kind of neat and I like it.)
![Updated DOM structure](https://github.com/mattyhempstead/yt-comment-sub-count/assets/1854245/a6ea8bfe-5eb9-47e9-a9c3-d99877db3b67)

This change detects this change and the addon should once again work (although I couldn't test this with the old format DOM). So for now and at least in theory the addon should support both structures.